### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,9 @@
 /dist/
 /tmp/
 
+# ignore .git folder on npm install as dependency
+/.git/
+
 # dependencies
 /bower_components/
 


### PR DESCRIPTION
Resolves npm error: npm ERR! git [path]/node_modules/ember-indexeddb: Appears to be a git repo or submodule.

This error is caused when npm install includes a .git folder, which should not happen when installing as a dependency

Resolves: https://github.com/mydea/ember-indexeddb/issues/67