### PR TITLE
Update to Dexie 3

### DIFF
--- a/addon-test-support/helpers/indexed-db.js
+++ b/addon-test-support/helpers/indexed-db.js
@@ -37,6 +37,7 @@ export function setupIndexedDb(hooks) {
     await wait();
     await run(() => indexedDb.waitForQueueTask.perform());
     await run(() => indexedDb.waitForQueueTask.perform());
+    await indexedDb.dropDatabaseTask.perform();
   });
 }
 

--- a/addon/services/indexed-db-configuration.js
+++ b/addon/services/indexed-db-configuration.js
@@ -26,21 +26,26 @@ export default class IndexedDbConfigurationService extends Service {
    *
    * upgrade is a function that gets a transaction as parameter, which can be used to run database migrations.
    * See https://github.com/dfahlander/Dexie.js/wiki/Version.upgrade() for detailed options/examples.
+   * 
+   * Note that in newer versions of Dexie, you do not need to keep old version definitions anymnore, unless they contain upgrade instructions.
+   * Instead, each version has to contain the full, current schema (not just the updates to the last version).
    *
    * An example would be:
    *
    * ```js
-   * version1: {
+   * // You can delete this safely when adding version2, as it does not contain an upgrade
+   * version1 = {
    *    stores: {
    *      'task': '&id*,isRead',
    *      'task-item': '&id'
    *    }
    * },
    *
-   * version2: {
-   *    stores: {
+   * version2 = {
+   *     stores: {
+   *      'task': '&id*,isRead',
    *      'task-item': '&id,*isNew'
-   *    },
+   *    }
    *    upgrade: (transaction) => {
    *     transaction['task-item'].each((taskItem, cursor) => {
            taskItem.isNew = 0;

--- a/addon/services/indexed-db-configuration.js
+++ b/addon/services/indexed-db-configuration.js
@@ -155,7 +155,7 @@ export default class IndexedDbConfigurationService extends Service {
    * @public
    */
   setupDatabase(db) {
-    let currentVersion = this.currentVersion;
+    let { currentVersion } = this;
 
     assert(
       'You need to override services/indexed-db-configuration.js and provide at least one version.',
@@ -164,7 +164,13 @@ export default class IndexedDbConfigurationService extends Service {
 
     for (let v = 1; v <= currentVersion; v++) {
       let versionName = `version${v}`;
-      let { stores, upgrade } = this[versionName];
+      let versionDefinition = this[versionName];
+
+      if (!versionDefinition) {
+        continue;
+      }
+
+      let { stores, upgrade } = versionDefinition;
 
       if (stores && upgrade) {
         db.version(v).stores(stores).upgrade(upgrade);

--- a/blueprints/ember-indexeddb/files/__root__/services/indexed-db-configuration.js
+++ b/blueprints/ember-indexeddb/files/__root__/services/indexed-db-configuration.js
@@ -15,38 +15,36 @@ import { computed } from '@ember/object';
  * A full example configuration after some time of use could look like this:
  *
  * ```
- * export default IndexedDbConfigurationService.extend({
-    currentVersion: 2,
-    version1: computed(function() {
-      return {
-        stores: {
-          'project': '&id',
-          'todo': '&id'
-        }
-      };
-    }),
-    version2: computed(function() {
-      return {
-        stores: {
-          'tag': '&id'
-        }
-      };
-    })
-  });
+ * export default class ExtendedIndexedDbConfigurationService extends IndexedDbConfigurationService {
+    currentVersion = 2;
+
+    version1: {
+      stores: {
+        project: '&id',
+        todo: '&id'
+      }
+    },
+
+    version2: {
+      stores: {
+        project: '&id',
+        todo: '&id,title',
+        tag: '&id'
+      }
+    }
+  }
  * ```
  *
  * For more information, please see https://mydea.github.io/ember-indexeddb/docs/modules/Configuring%20your%20database.html
  */
-export default IndexedDbConfigurationService.extend({
-  currentVersion: 1,
+export default class ExtendedIndexedDbConfigurationService extends IndexedDbConfigurationService {
+  currentVersion = 1;
 
-  version1: computed(function () {
-    return {
-      stores: {
-        // Add your tables here, like this: 'item': '&id'
-        // When using the ember data adapter, add one entry per model, where the key is your model name
-        // For example, if you have a model named "my-item", add an entry: `'my-item': '&id'
-      },
-    };
-  }),
-});
+  version1 = {
+    stores: {
+      // Add your tables here, like this: 'item': '&id'
+      // When using the ember data adapter, add one entry per model, where the key is your model name
+      // For example, if you have a model named "my-item", add an entry: `'my-item': '&id'
+    },
+  };
+}

--- a/tests/unit/services/indexed-db-test.js
+++ b/tests/unit/services/indexed-db-test.js
@@ -4,6 +4,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { setupIndexedDb } from 'ember-indexeddb/test-support/helpers/indexed-db';
 import { run } from '@ember/runloop';
+import IndexedDbService from 'ember-indexeddb/services/indexed-db';
+import IndexedDbConfigurationService from 'ember-indexeddb/services/indexed-db-configuration';
 
 const createMockDb = function () {
   return {
@@ -33,117 +35,935 @@ const createMockDb = function () {
 
 module('Unit | Service | indexed-db', function (hooks) {
   setupTest(hooks);
-  setupIndexedDb(hooks);
 
-  // service.setup() is hard to test as it relies on the global Dexie
+  module('mocked', function (hooks) {
+    setupIndexedDb(hooks);
 
-  test('add works', function (assert) {
-    let done = assert.async();
-    assert.expect(6);
-    let db = createMockDb();
+    // service.setup() is hard to test as it relies on the global Dexie
 
-    let putItems = [];
-    let promises = [];
+    test('add works', function (assert) {
+      let done = assert.async();
+      assert.expect(6);
+      let db = createMockDb();
 
-    db.items = {
-      bulkPut(items) {
-        putItems.push(items);
-        let promise = RSVP.Promise.resolve(items);
-        promises.push(promise);
-        return promise;
-      },
-    };
+      let putItems = [];
+      let promises = [];
 
-    let service = this.owner.factoryFor('service:indexed-db').create({
-      db,
-    });
-
-    let item = {
-      id: 'TEST-1',
-      type: 'items',
-    };
-    let promise1 = service.add('items', item);
-
-    let response1 = [
-      {
-        id: 'TEST-1',
-        json: {
-          id: 'TEST-1',
-          attributes: {},
-          relationships: {},
-          type: 'items',
+      db.items = {
+        bulkPut(items) {
+          putItems.push(items);
+          let promise = RSVP.Promise.resolve(items);
+          promises.push(promise);
+          return promise;
         },
-      },
-    ];
-    assert.deepEqual(putItems, [response1], 'adding one items works');
+      };
 
-    promise1.then((data) => {
-      assert.deepEqual(
-        data,
-        response1,
-        'promise 1 resolves with array of data'
-      );
-    });
+      let service = this.owner.factoryFor('service:indexed-db').create({
+        db,
+      });
 
-    putItems = [];
-    let item2 = {
-      id: 'TEST-2',
-      type: 'items',
-    };
-    let promise2 = service.add('items', [item, item2]);
-
-    let response2 = [
-      {
+      let item = {
         id: 'TEST-1',
-        json: {
+        type: 'items',
+      };
+      let promise1 = service.add('items', item);
+
+      let response1 = [
+        {
           id: 'TEST-1',
-          attributes: {},
-          relationships: {},
-          type: 'items',
+          json: {
+            id: 'TEST-1',
+            attributes: {},
+            relationships: {},
+            type: 'items',
+          },
         },
-      },
-      {
+      ];
+      assert.deepEqual(putItems, [response1], 'adding one items works');
+
+      promise1.then((data) => {
+        assert.deepEqual(
+          data,
+          response1,
+          'promise 1 resolves with array of data'
+        );
+      });
+
+      putItems = [];
+      let item2 = {
         id: 'TEST-2',
-        json: {
-          id: 'TEST-2',
-          attributes: {},
-          relationships: {},
-          type: 'items',
+        type: 'items',
+      };
+      let promise2 = service.add('items', [item, item2]);
+
+      let response2 = [
+        {
+          id: 'TEST-1',
+          json: {
+            id: 'TEST-1',
+            attributes: {},
+            relationships: {},
+            type: 'items',
+          },
         },
-      },
-    ];
-    assert.deepEqual(putItems, [response2], 'adding two items works');
+        {
+          id: 'TEST-2',
+          json: {
+            id: 'TEST-2',
+            attributes: {},
+            relationships: {},
+            type: 'items',
+          },
+        },
+      ];
+      assert.deepEqual(putItems, [response2], 'adding two items works');
 
-    let promiseQueue = service._promiseQueue;
-    assert.equal(
-      promiseQueue.length,
-      2,
-      'there are two items in the promise queue'
-    );
-
-    promise2.then((data) => {
-      assert.deepEqual(
-        data,
-        response2,
-        'promise 2 resolves with array of data'
+      let promiseQueue = service._promiseQueue;
+      assert.equal(
+        promiseQueue.length,
+        2,
+        'there are two items in the promise queue'
       );
+
+      promise2.then((data) => {
+        assert.deepEqual(
+          data,
+          response2,
+          'promise 2 resolves with array of data'
+        );
+      });
+
+      RSVP.all([promise1, promise2]).then(() => {
+        assert.equal(
+          get(promiseQueue, 'length'),
+          0,
+          'promise queue is cleared'
+        );
+        done();
+      });
     });
 
-    RSVP.all([promise1, promise2]).then(() => {
-      assert.equal(get(promiseQueue, 'length'), 0, 'promise queue is cleared');
-      done();
+    test('it does not open multiple db instances on setup', async function (assert) {
+      let service = this.owner.lookup('service:indexed-db');
+
+      await run(() => service.setup());
+      let { db } = service;
+      assert.ok(db, 'database is setup');
+
+      await run(() => service.setup());
+      let db2 = service.db;
+      assert.equal(db2, db, 'db is not overwritten');
     });
   });
 
-  test('it does not open multiple db instances on setup', async function (assert) {
-    let service = this.owner.lookup('service:indexed-db');
+  module('DB migration', function (hooks) {
+    hooks.afterEach(async function () {
+      let service = this.owner.lookup('service:indexed-db');
 
-    await run(() => service.setup());
-    let { db } = service;
-    assert.ok(db, 'database is setup');
+      // Cleanup
+      await service.dropDatabaseTask.perform();
+    });
 
-    await run(() => service.setup());
-    let db2 = service.db;
-    assert.equal(db2, db, 'db is not overwritten');
+    test('it works with just one version', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id',
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello' },
+      });
+
+      let item = await service.queryRecord('item-1', { name: 'hello' });
+
+      assert.deepEqual(item, {
+        id: '1',
+        json: {
+          attributes: {
+            name: 'hello',
+          },
+          id: '1',
+          relationships: {},
+          type: 'item-1',
+        },
+      });
+    });
+
+    test('it works with an upgrade', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id',
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+      let configService = this.owner.lookup('service:indexed-db-configuration');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello' },
+      });
+
+      let item = await service.queryRecord('item-1', { name: 'hello' });
+
+      assert.deepEqual(item, {
+        id: '1',
+        json: {
+          attributes: {
+            name: 'hello',
+          },
+          id: '1',
+          relationships: {},
+          type: 'item-1',
+        },
+      });
+
+      // Now run an upgrade...
+      configService.currentVersion = 2;
+      configService.version2 = {
+        stores: {
+          'item-1': '&id,isNew',
+        },
+        upgrade: (transaction) => {
+          transaction['item-1'].each((taskItem, cursor) => {
+            taskItem.isNew = 1;
+            cursor.update(taskItem);
+          });
+        },
+      };
+
+      await service.db.close();
+      service.db = null;
+      await service.setupTask.perform();
+
+      let newItem = await service.queryRecord('item-1', { name: 'hello' });
+
+      assert.deepEqual(newItem, {
+        id: '1',
+        isNew: 1,
+        json: {
+          attributes: {
+            name: 'hello',
+          },
+          id: '1',
+          relationships: {},
+          type: 'item-1',
+        },
+      });
+    });
+
+    test('it works without an upgrade', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 5;
+
+        version5 = {
+          stores: {
+            'item-1': '&id,name',
+          },
+        };
+
+        mapTable = {
+          'item-1': (item) => {
+            return {
+              id: this._toString(item.id),
+              name: item.attributes.name,
+              json: this._cleanObject(item),
+            };
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+      let configService = this.owner.lookup('service:indexed-db-configuration');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello' },
+      });
+
+      let item = await service.queryRecord('item-1', { name: 'hello' });
+
+      assert.deepEqual(item, {
+        id: '1',
+        name: 'hello',
+        json: {
+          attributes: {
+            name: 'hello',
+          },
+          id: '1',
+          relationships: {},
+          type: 'item-1',
+        },
+      });
+
+      // Now run an upgrade...
+      configService.currentVersion = 6;
+      delete configService.version5;
+      configService.version6 = {
+        stores: {
+          'item-1': '&id,name,isNew',
+        },
+      };
+      configService.mapTable = {
+        'item-1': (item) => {
+          return {
+            id: configService._toString(item.id),
+            name: item.attributes.name,
+            isNew: configService._toZeroOne(item.attributes.isNew),
+            json: configService._cleanObject(item),
+          };
+        },
+      };
+
+      await service.db.close();
+      service.db = null;
+      await service.setupTask.perform();
+
+      let oldItem = await service.queryRecord('item-1', { name: 'hello' });
+
+      assert.deepEqual(oldItem, {
+        id: '1',
+        name: 'hello',
+        json: {
+          attributes: {
+            name: 'hello',
+          },
+          id: '1',
+          relationships: {},
+          type: 'item-1',
+        },
+      });
+
+      // Add another new one
+      await service.add('item-1', {
+        id: '2',
+        type: 'item-1',
+        attributes: { name: 'hello2', isNew: true },
+      });
+
+      let newItem = await service.queryRecord('item-1', { isNew: true });
+
+      assert.deepEqual(newItem, {
+        id: '2',
+        name: 'hello2',
+        isNew: 1,
+        json: {
+          attributes: {
+            name: 'hello2',
+            isNew: true,
+          },
+          id: '2',
+          relationships: {},
+          type: 'item-1',
+        },
+      });
+    });
+
+    test('it works with just one higher version', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 11;
+
+        version11 = {
+          stores: {
+            'item-1': '&id',
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello' },
+      });
+
+      let item = await service.queryRecord('item-1', { name: 'hello' });
+
+      assert.deepEqual(item, {
+        id: '1',
+        json: {
+          attributes: {
+            name: 'hello',
+          },
+          id: '1',
+          relationships: {},
+          type: 'item-1',
+        },
+      });
+    });
+  });
+
+  module('querying', function (hooks) {
+    hooks.afterEach(async function () {
+      let service = this.owner.lookup('service:indexed-db');
+
+      // Cleanup
+      await service.dropDatabaseTask.perform();
+    });
+
+    test('it allows to filter for an indexed field', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id,name',
+          },
+        };
+
+        mapTable = {
+          'item-1': (item) => {
+            return {
+              id: this._toString(item.id),
+              name: item.attributes.name,
+              json: this._cleanObject(item),
+            };
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: true },
+      });
+      await service.add('item-1', {
+        id: '2',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: false },
+      });
+      await service.add('item-1', {
+        id: '3',
+        type: 'item-1',
+        attributes: { name: 'hello2', isNew: true },
+      });
+
+      let items = await service.query('item-1', {
+        name: 'hello',
+      });
+
+      assert.deepEqual(
+        items,
+        [
+          {
+            id: '1',
+            json: {
+              attributes: {
+                isNew: true,
+                name: 'hello',
+              },
+              id: '1',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello',
+          },
+          {
+            id: '2',
+            json: {
+              attributes: {
+                isNew: false,
+                name: 'hello',
+              },
+              id: '2',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello',
+          },
+        ],
+        'indexed search works'
+      );
+    });
+
+    test('it allows to filter for an unindexed fields', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id,name',
+          },
+        };
+
+        mapTable = {
+          'item-1': (item) => {
+            return {
+              id: this._toString(item.id),
+              name: item.attributes.name,
+              json: this._cleanObject(item),
+            };
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: true },
+      });
+      await service.add('item-1', {
+        id: '2',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: false },
+      });
+      await service.add('item-1', {
+        id: '3',
+        type: 'item-1',
+        attributes: { name: 'hello2', isNew: true },
+      });
+
+      let items = await service.query('item-1', {
+        isNew: true,
+      });
+
+      assert.deepEqual(
+        items,
+        [
+          {
+            id: '1',
+            json: {
+              attributes: {
+                isNew: true,
+                name: 'hello',
+              },
+              id: '1',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello',
+          },
+          {
+            id: '3',
+            json: {
+              attributes: {
+                isNew: true,
+                name: 'hello2',
+              },
+              id: '3',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello2',
+          },
+        ],
+        'non-indexed search works'
+      );
+    });
+
+    test('it allows to combine indexed & unindexed fields', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id,name',
+          },
+        };
+
+        mapTable = {
+          'item-1': (item) => {
+            return {
+              id: this._toString(item.id),
+              name: item.attributes.name,
+              json: this._cleanObject(item),
+            };
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: true },
+      });
+      await service.add('item-1', {
+        id: '2',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: false },
+      });
+      await service.add('item-1', {
+        id: '3',
+        type: 'item-1',
+        attributes: { name: 'hello2', isNew: true },
+      });
+
+      let items = await service.query('item-1', {
+        name: 'hello',
+        isNew: true,
+      });
+
+      assert.deepEqual(
+        items,
+        [
+          {
+            id: '1',
+            json: {
+              attributes: {
+                isNew: true,
+                name: 'hello',
+              },
+              id: '1',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello',
+          },
+        ],
+        'combi search works'
+      );
+    });
+
+    test('it allows to use a compound index', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id,[name+isNew]',
+          },
+        };
+
+        mapTable = {
+          'item-1': (item) => {
+            return {
+              id: this._toString(item.id),
+              name: item.attributes.name,
+              isNew: this._toZeroOne(item.attributes.isNew),
+              json: this._cleanObject(item),
+            };
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: true },
+      });
+      await service.add('item-1', {
+        id: '2',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: false },
+      });
+      await service.add('item-1', {
+        id: '3',
+        type: 'item-1',
+        attributes: { name: 'hello2', isNew: true },
+      });
+
+      let items = await service.query('item-1', {
+        name: 'hello',
+        isNew: true,
+      });
+
+      assert.deepEqual(
+        items,
+        [
+          {
+            id: '1',
+            json: {
+              attributes: {
+                isNew: true,
+                name: 'hello',
+              },
+              id: '1',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello',
+            isNew: 1,
+          },
+        ],
+        'combi search works'
+      );
+    });
+
+    test('it allows to provide an empty query object', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id,name',
+          },
+        };
+
+        mapTable = {
+          'item-1': (item) => {
+            return {
+              id: this._toString(item.id),
+              name: item.attributes.name,
+              json: this._cleanObject(item),
+            };
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: true },
+      });
+      await service.add('item-1', {
+        id: '2',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: false },
+      });
+      await service.add('item-1', {
+        id: '3',
+        type: 'item-1',
+        attributes: { name: 'hello2', isNew: true },
+      });
+
+      let items = await service.query('item-1', {});
+
+      assert.deepEqual(
+        items,
+        [
+          {
+            id: '1',
+            json: {
+              attributes: {
+                isNew: true,
+                name: 'hello',
+              },
+              id: '1',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello',
+          },
+          {
+            id: '2',
+            json: {
+              attributes: {
+                isNew: false,
+                name: 'hello',
+              },
+              id: '2',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello',
+          },
+          {
+            id: '3',
+            json: {
+              attributes: {
+                isNew: true,
+                name: 'hello2',
+              },
+              id: '3',
+              relationships: {},
+              type: 'item-1',
+            },
+            name: 'hello2',
+          },
+        ],
+        'empty query search works'
+      );
+    });
+
+    test('it handles empty results', async function (assert) {
+      class TestIndexedDbConfigurationService extends IndexedDbConfigurationService {
+        currentVersion = 1;
+
+        version1 = {
+          stores: {
+            'item-1': '&id,name',
+          },
+        };
+
+        mapTable = {
+          'item-1': (item) => {
+            return {
+              id: this._toString(item.id),
+              name: item.attributes.name,
+              json: this._cleanObject(item),
+            };
+          },
+        };
+      }
+
+      class TestIndexedDbService extends IndexedDbService {
+        databaseName = 'test-db-migration-1';
+      }
+
+      this.owner.register('service:indexed-db', TestIndexedDbService);
+      this.owner.register(
+        'service:indexed-db-configuration',
+        TestIndexedDbConfigurationService
+      );
+
+      let service = this.owner.lookup('service:indexed-db');
+
+      await service.setupTask.perform();
+
+      // Try interacting with it
+      await service.add('item-1', {
+        id: '1',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: true },
+      });
+      await service.add('item-1', {
+        id: '2',
+        type: 'item-1',
+        attributes: { name: 'hello', isNew: false },
+      });
+      await service.add('item-1', {
+        id: '3',
+        type: 'item-1',
+        attributes: { name: 'hello2', isNew: true },
+      });
+
+      let items = await service.query('item-1', {
+        name: 'blub',
+      });
+
+      assert.deepEqual(items, [], 'not-found search works');
+    });
   });
 });


### PR DESCRIPTION
See: https://github.com/dfahlander/Dexie.js/releases/tag/v3.0.0

Dexie 3 introduced some breaking changes.
Mainly, it changes how DB migrations are handled:

* Each version should contain the full schema, not just the changes to the last one
* Unless there is an `upgrade()`, you can safely remove older versions from your code now

Also, there are some changes to how querying works, which are adjusted to in this PR.
This also introduces tests for the migration functionality, as well as for the different query types.

Finally, you can now also set `_shouldLogQuery = true` on the indexed-db service to make it output which index is used for a given query. This can be used to optimize your schema.

This PR also updates documentation accordingly (and moves to ES6 syntax everywhere).